### PR TITLE
Add support for new named parameters

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1290,10 +1290,25 @@ module.exports = grammar({
 
     // Call Expression
     // -------------------------
+    call_arg_param_path_element: $ => prec(1, choice(
+      seq('[', $._expr, ']'),
+      seq('[', $._expr, '..', $._expr, ']'),
+    )),
+    call_arg_param_path: $ => repeat1($.call_arg_param_path_element),
+
+    call_arg: $ => choice(
+      seq($.call_arg_param_path),
+      seq($.ident, ':', $._expr),
+      $.type,
+      $._expr,
+      seq('$vasplat', '(', optional($.range_expr), ')'), // < 0.7.0, deprecated >= 0.6.2
+      seq('$vasplat', optional(seq('[', $.range_expr, ']'))), // >= 0.6.2
+      seq('...', $._expr),
+    ),
     _call_arg_list: $ => choice(
-      commaSepTrailing1($.arg),
+      commaSepTrailing1($.call_arg),
       seq(
-        commaSepTrailing($.arg),
+        commaSepTrailing($.call_arg),
         seq(';', optional($._parameters)),
       ),
     ),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -19,7 +19,7 @@
 (initializer_list (arg (param_path (param_path_element (ident) @variable.member))))
 ;; 2) Parameter
 (parameter name: (_) @variable.parameter)
-(call_invocation (arg (param_path (param_path_element [(ident) (ct_ident)] @variable.parameter))))
+(call_invocation (call_arg (ident) @variable.parameter))
 (enum_param_declaration (ident) @variable.parameter)
 ;; 3) Declaration
 (global_declaration (ident) @variable.declaration)

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -7842,6 +7842,179 @@
         }
       ]
     },
+    "call_arg_param_path_element": {
+      "type": "PREC",
+      "value": 1,
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expr"
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              }
+            ]
+          },
+          {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "["
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expr"
+              },
+              {
+                "type": "STRING",
+                "value": ".."
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_expr"
+              },
+              {
+                "type": "STRING",
+                "value": "]"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "call_arg_param_path": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "call_arg_param_path_element"
+      }
+    },
+    "call_arg": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "call_arg_param_path"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "ident"
+            },
+            {
+              "type": "STRING",
+              "value": ":"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_expr"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "type"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_expr"
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "$vasplat"
+            },
+            {
+              "type": "STRING",
+              "value": "("
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "range_expr"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "STRING",
+              "value": ")"
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "$vasplat"
+            },
+            {
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": "["
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "range_expr"
+                    },
+                    {
+                      "type": "STRING",
+                      "value": "]"
+                    }
+                  ]
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "..."
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_expr"
+            }
+          ]
+        }
+      ]
+    },
     "_call_arg_list": {
       "type": "CHOICE",
       "members": [
@@ -7850,7 +8023,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "arg"
+              "name": "call_arg"
             },
             {
               "type": "REPEAT",
@@ -7863,7 +8036,7 @@
                   },
                   {
                     "type": "SYMBOL",
-                    "name": "arg"
+                    "name": "call_arg"
                   }
                 ]
               }
@@ -7893,7 +8066,7 @@
                   "members": [
                     {
                       "type": "SYMBOL",
-                      "name": "arg"
+                      "name": "call_arg"
                     },
                     {
                       "type": "REPEAT",
@@ -7906,7 +8079,7 @@
                           },
                           {
                             "type": "SYMBOL",
-                            "name": "arg"
+                            "name": "call_arg"
                           }
                         ]
                       }
@@ -8880,3 +9053,4 @@
   ],
   "supertypes": []
 }
+

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2724,6 +2724,353 @@
     }
   },
   {
+    "type": "call_arg",
+    "named": true,
+    "fields": {
+      "lambda_body": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "compound_stmt",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "assignment_expr",
+          "named": true
+        },
+        {
+          "type": "at_ident",
+          "named": true
+        },
+        {
+          "type": "binary_expr",
+          "named": true
+        },
+        {
+          "type": "builtin",
+          "named": true
+        },
+        {
+          "type": "bytes_expr",
+          "named": true
+        },
+        {
+          "type": "call_arg_param_path",
+          "named": true
+        },
+        {
+          "type": "call_expr",
+          "named": true
+        },
+        {
+          "type": "cast_expr",
+          "named": true
+        },
+        {
+          "type": "char_literal",
+          "named": true
+        },
+        {
+          "type": "const_ident",
+          "named": true
+        },
+        {
+          "type": "ct_ident",
+          "named": true
+        },
+        {
+          "type": "elvis_orelse_expr",
+          "named": true
+        },
+        {
+          "type": "expr_block",
+          "named": true
+        },
+        {
+          "type": "field_expr",
+          "named": true
+        },
+        {
+          "type": "flat_path",
+          "named": true
+        },
+        {
+          "type": "hash_ident",
+          "named": true
+        },
+        {
+          "type": "ident",
+          "named": true
+        },
+        {
+          "type": "initializer_list",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "lambda_declaration",
+          "named": true
+        },
+        {
+          "type": "lambda_expr",
+          "named": true
+        },
+        {
+          "type": "module_ident_expr",
+          "named": true
+        },
+        {
+          "type": "optional_expr",
+          "named": true
+        },
+        {
+          "type": "paren_expr",
+          "named": true
+        },
+        {
+          "type": "range_expr",
+          "named": true
+        },
+        {
+          "type": "raw_string_literal",
+          "named": true
+        },
+        {
+          "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "rethrow_expr",
+          "named": true
+        },
+        {
+          "type": "string_expr",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "subscript_expr",
+          "named": true
+        },
+        {
+          "type": "ternary_expr",
+          "named": true
+        },
+        {
+          "type": "trailing_generic_expr",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "type_access_expr",
+          "named": true
+        },
+        {
+          "type": "unary_expr",
+          "named": true
+        },
+        {
+          "type": "update_expr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "call_arg_param_path",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "call_arg_param_path_element",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "call_arg_param_path_element",
+    "named": true,
+    "fields": {
+      "lambda_body": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "compound_stmt",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": true,
+      "required": false,
+      "types": [
+        {
+          "type": "assignment_expr",
+          "named": true
+        },
+        {
+          "type": "at_ident",
+          "named": true
+        },
+        {
+          "type": "binary_expr",
+          "named": true
+        },
+        {
+          "type": "builtin",
+          "named": true
+        },
+        {
+          "type": "bytes_expr",
+          "named": true
+        },
+        {
+          "type": "call_expr",
+          "named": true
+        },
+        {
+          "type": "cast_expr",
+          "named": true
+        },
+        {
+          "type": "char_literal",
+          "named": true
+        },
+        {
+          "type": "const_ident",
+          "named": true
+        },
+        {
+          "type": "ct_ident",
+          "named": true
+        },
+        {
+          "type": "elvis_orelse_expr",
+          "named": true
+        },
+        {
+          "type": "expr_block",
+          "named": true
+        },
+        {
+          "type": "field_expr",
+          "named": true
+        },
+        {
+          "type": "flat_path",
+          "named": true
+        },
+        {
+          "type": "hash_ident",
+          "named": true
+        },
+        {
+          "type": "ident",
+          "named": true
+        },
+        {
+          "type": "initializer_list",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "lambda_declaration",
+          "named": true
+        },
+        {
+          "type": "lambda_expr",
+          "named": true
+        },
+        {
+          "type": "module_ident_expr",
+          "named": true
+        },
+        {
+          "type": "optional_expr",
+          "named": true
+        },
+        {
+          "type": "paren_expr",
+          "named": true
+        },
+        {
+          "type": "raw_string_literal",
+          "named": true
+        },
+        {
+          "type": "real_literal",
+          "named": true
+        },
+        {
+          "type": "rethrow_expr",
+          "named": true
+        },
+        {
+          "type": "string_expr",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "subscript_expr",
+          "named": true
+        },
+        {
+          "type": "ternary_expr",
+          "named": true
+        },
+        {
+          "type": "trailing_generic_expr",
+          "named": true
+        },
+        {
+          "type": "type",
+          "named": true
+        },
+        {
+          "type": "type_access_expr",
+          "named": true
+        },
+        {
+          "type": "unary_expr",
+          "named": true
+        },
+        {
+          "type": "update_expr",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "call_expr",
     "named": true,
     "fields": {
@@ -3053,7 +3400,7 @@
       "required": false,
       "types": [
         {
-          "type": "arg",
+          "type": "call_arg",
           "named": true
         },
         {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -86,11 +86,6 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
-typedef struct {
-  int32_t start;
-  int32_t end;
-} TSCharacterRange;
-
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -130,24 +125,6 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
-  uint32_t index = 0;
-  uint32_t size = len - index;
-  while (size > 1) {
-    uint32_t half_size = size / 2;
-    uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
-    if (lookahead >= range->start && lookahead <= range->end) {
-      return true;
-    } else if (lookahead > range->end) {
-      index = mid_index;
-    }
-    size -= half_size;
-  }
-  TSCharacterRange *range = &ranges[index];
-  return (lookahead >= range->start && lookahead <= range->end);
-}
-
 /*
  *  Lexer Macros
  */
@@ -175,17 +152,6 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {                          \
     state = state_value;     \
     goto next_state;         \
-  }
-
-#define ADVANCE_MAP(...)                                              \
-  {                                                                   \
-    static const uint16_t map[] = { __VA_ARGS__ };                    \
-    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
-      if (map[i] == lookahead) {                                      \
-        state = map[i + 1];                                           \
-        goto next_state;                                              \
-      }                                                               \
-    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -237,15 +203,14 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }                                 \
   }}
 
-#define REDUCE(symbol_name, children, precedence, prod_id) \
-  {{                                                       \
-    .reduce = {                                            \
-      .type = TSParseActionTypeReduce,                     \
-      .symbol = symbol_name,                               \
-      .child_count = children,                             \
-      .dynamic_precedence = precedence,                    \
-      .production_id = prod_id                             \
-    },                                                     \
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
   }}
 
 #define RECOVER()                    \

--- a/test/corpus/declaration.txt
+++ b/test/corpus/declaration.txt
@@ -39,7 +39,7 @@ fn void main() {
                 (ident))
               ident: (ident))
             arguments: (call_invocation
-              (arg
+              (call_arg
                 (string_literal
                   (string_content)
                   (escape_sequence))))))))))

--- a/test/corpus/expression.txt
+++ b/test/corpus/expression.txt
@@ -795,9 +795,9 @@ fn void main() {
           (call_expr
             (ident)
             (call_invocation
-              (arg
+              (call_arg
                 (ident))
-              (arg
+              (call_arg
                 (lambda_expr
                   (lambda_declaration
                     (fn_parameter_list
@@ -811,9 +811,9 @@ fn void main() {
           (call_expr
             (ident)
             (call_invocation
-              (arg
+              (call_arg
                 (ident))
-              (arg
+              (call_arg
                 (lambda_declaration
                   (type
                     (base_type
@@ -1088,9 +1088,9 @@ fn void main() {
           (call_expr
             (ident)
             (call_invocation
-              (arg
+              (call_arg
                 (ident))
-              (arg
+              (call_arg
                 (ident)))))
         (expr_stmt
           (call_expr
@@ -1099,7 +1099,7 @@ fn void main() {
               (access_ident
                 (ident)))
             (call_invocation
-              (arg
+              (call_arg
                 (ident)))))
         (expr_stmt
           (call_expr
@@ -1262,7 +1262,7 @@ fn void main() {
               (call_expr
                 (ident)
                 (call_invocation
-                  (arg
+                  (call_arg
                     (string_literal
                       (string_content)
                       (escape_sequence))))))))))))
@@ -1311,7 +1311,7 @@ fn void main() {
               (call_expr
                 (ident)
                 (call_invocation
-                  (arg
+                  (call_arg
                     (string_literal
                       (string_content)
                       (escape_sequence))))))))))))
@@ -1353,7 +1353,7 @@ fn void main() {
                     (ident))
                   (ident))
                 (call_invocation
-                  (arg
+                  (call_arg
                     (string_literal
                       (string_content))))))))
         (declaration_stmt
@@ -1542,7 +1542,7 @@ fn void main() {
           (call_expr
             (ident)
             (call_invocation
-              (arg
+              (call_arg
                 (assignment_expr
                   (ident)
                   (lambda_expr
@@ -1578,3 +1578,70 @@ fn void main() {
                               (call_invocation))
                             (integer_literal)))
                         (string_literal)))))))))))))
+
+================================================================================
+Function calls
+================================================================================
+
+fn int test(int first, int second) {
+  return first + second;
+}
+
+fn void main() {
+    test(1,2);
+    test(second: 1, first: 2);
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (func_definition
+    (func_header
+      return_type: (type
+        (base_type
+          (base_type_name)))
+      name: (ident))
+    (fn_parameter_list
+          (parameter
+            type: (type
+              (base_type
+                (base_type_name)))
+            name: (ident))
+          (parameter
+            type: (type
+              (base_type
+                (base_type_name)))
+            name: (ident)))
+    body: (macro_func_body
+      (compound_stmt
+        (return_stmt
+              (binary_expr
+                left: (ident)
+                right: (ident))))))
+  (func_definition
+        (func_header
+          return_type: (type
+            (base_type
+              (base_type_name)))
+          name: (ident))
+        (fn_parameter_list)
+        body: (macro_func_body
+          (compound_stmt
+            (expr_stmt
+              (call_expr
+                function: (ident)
+                arguments: (call_invocation
+                  (call_arg
+                    (integer_literal))
+                  (call_arg
+                    (integer_literal)))))
+            (expr_stmt
+              (call_expr
+                function: (ident)
+                arguments: (call_invocation
+                  (call_arg
+                    (ident)
+                    (integer_literal))
+                  (call_arg
+                    (ident)
+                    (integer_literal)))))))))

--- a/test/corpus/statement.txt
+++ b/test/corpus/statement.txt
@@ -144,7 +144,7 @@ fn void main() {
               (call_expr
                 (ident)
                 (call_invocation
-                  (arg
+                  (call_arg
                     (integer_literal)))))))
         (while_stmt
           (paren_cond
@@ -162,7 +162,7 @@ fn void main() {
               (call_expr
                 (ident)
                 (call_invocation
-                  (arg
+                  (call_arg
                     (call_expr
                       (field_expr
                         (ident)
@@ -199,7 +199,7 @@ fn void main() {
               (call_expr
                 (ident)
                 (call_invocation
-                  (arg
+                  (call_arg
                     (ident)))))))))))
 
 ================================================================================
@@ -256,7 +256,7 @@ fn void main() {
               (call_expr
                 (ident)
                 (call_invocation
-                  (arg
+                  (call_arg
                     (ident)))))))
         (for_stmt
           (for_cond
@@ -275,7 +275,7 @@ fn void main() {
               (call_expr
                 (ident)
                 (call_invocation
-                  (arg
+                  (call_arg
                     (ident)))))))
         (for_stmt
           (for_cond)
@@ -284,7 +284,7 @@ fn void main() {
               (call_expr
                 (ident)
                 (call_invocation
-                  (arg
+                  (call_arg
                     (integer_literal)))))))
         (for_stmt
           (for_cond
@@ -296,7 +296,7 @@ fn void main() {
               (call_expr
                 (ident)
                 (call_invocation
-                  (arg
+                  (call_arg
                     (integer_literal)))))))
         (for_stmt
           (for_cond
@@ -308,7 +308,7 @@ fn void main() {
               (call_expr
                 (ident)
                 (call_invocation
-                  (arg
+                  (call_arg
                     (integer_literal)))))))))))
 
 ================================================================================
@@ -349,12 +349,12 @@ fn void main() {
                     (ident))
                   (ident))
                 (call_invocation
-                  (arg
+                  (call_arg
                     (string_literal
                       (string_content)))
-                  (arg
+                  (call_arg
                     (ident))
-                  (arg
+                  (call_arg
                     (ident)))))))))))
 
 ================================================================================
@@ -611,6 +611,6 @@ fn void main() {
                       (ident))
                     (ident))
                   (call_invocation
-                    (arg
+                    (call_arg
                       (string_literal
                         (string_content)))))))))))))


### PR DESCRIPTION
Named parameters have been changed from `.param = value` to `param: value`.
This required some bigger changes, as I had to split initialization args from call args, since structures still use `.attribute: value` and this was shared.

My experience with tree-sitter grammar is very minimal, so the changes I made might not be the best solution, but I'm happy to adapt it.