### PR TITLE
New doc comment syntaxt

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -169,9 +169,9 @@ module.exports = grammar({
     ),
 
     doc_comment: $ => seq(
-      '/**',
+      '<*',
       $.doc_comment_text,
-      '*/',
+      '*>',
     ),
 
     block_comment: $ => seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -380,7 +380,7 @@
       "members": [
         {
           "type": "STRING",
-          "value": "/**"
+          "value": "<*"
         },
         {
           "type": "SYMBOL",
@@ -388,7 +388,7 @@
         },
         {
           "type": "STRING",
-          "value": "*/"
+          "value": "*>"
         }
       ]
     },
@@ -8962,3 +8962,4 @@
   ],
   "supertypes": []
 }
+

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -17383,6 +17383,10 @@
     "named": false
   },
   {
+    "type": "*>",
+    "named": false
+  },
+  {
     "type": "+",
     "named": false
   },
@@ -17435,10 +17439,6 @@
     "named": false
   },
   {
-    "type": "/**",
-    "named": false
-  },
-  {
     "type": "/=",
     "named": false
   },
@@ -17456,6 +17456,10 @@
   },
   {
     "type": "<",
+    "named": false
+  },
+  {
+    "type": "<*",
     "named": false
   },
   {

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -12,11 +12,11 @@ void tree_sitter_c3_external_scanner_reset(void *p) {}
 unsigned tree_sitter_c3_external_scanner_serialize(void *p, char *buffer) { return 0; }
 void tree_sitter_c3_external_scanner_deserialize(void *p, const char *b, unsigned n) {}
 
-static bool scan_block_comment(TSLexer *lexer, bool allow_eof) {
+static bool scan_block_comment(TSLexer *lexer) {
   for (int stack = 0;;) {
     if (lexer->eof(lexer)) {
       lexer->mark_end(lexer);
-      return allow_eof;
+      return true;
     }
 
     int32_t c = lexer->lookahead;
@@ -36,6 +36,28 @@ static bool scan_block_comment(TSLexer *lexer, bool allow_eof) {
         if (stack == -1) {
           return true;
         }
+      }
+    } else {
+      lexer->advance(lexer, false);
+    }
+  }
+  return false;
+}
+
+static bool scan_doc_comment(TSLexer *lexer) {
+  // We stop at EOF or when we find the closing tag `*>`
+  while(true) {
+    if (lexer->eof(lexer)) {
+      lexer->mark_end(lexer);
+      return false;
+    }
+
+    if (lexer->lookahead == '*') {
+      lexer->mark_end(lexer);
+      lexer->advance(lexer, false);
+      if (lexer->lookahead == '>') {
+        lexer->advance(lexer, false);
+        return true;
       }
     } else {
       lexer->advance(lexer, false);
@@ -223,14 +245,14 @@ static bool scan_real_literal(TSLexer *lexer) {
   return true;
 }
 
-bool tree_sitter_c3_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
-  // Allow block comments ending at EOF, but not doc comments.
-  if (valid_symbols[BLOCK_COMMENT_TEXT] && scan_block_comment(lexer, true)) {
-    lexer->result_symbol = BLOCK_COMMENT_TEXT;
+bool tree_sitter_c3_external_scanner_scan(void *payload, TSLexer *lexer,
+                                          const bool *valid_symbols) {
+  if (valid_symbols[DOC_COMMENT_TEXT] && scan_doc_comment(lexer)) {
+    lexer->result_symbol = DOC_COMMENT_TEXT;
     return true;
   }
-  if (valid_symbols[DOC_COMMENT_TEXT] && scan_block_comment(lexer, false)) {
-    lexer->result_symbol = DOC_COMMENT_TEXT;
+  if (valid_symbols[BLOCK_COMMENT_TEXT] && scan_block_comment(lexer)) {
+    lexer->result_symbol = BLOCK_COMMENT_TEXT;
     return true;
   }
 

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -86,11 +86,6 @@ typedef union {
   } entry;
 } TSParseActionEntry;
 
-typedef struct {
-  int32_t start;
-  int32_t end;
-} TSCharacterRange;
-
 struct TSLanguage {
   uint32_t version;
   uint32_t symbol_count;
@@ -130,24 +125,6 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
-  uint32_t index = 0;
-  uint32_t size = len - index;
-  while (size > 1) {
-    uint32_t half_size = size / 2;
-    uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
-    if (lookahead >= range->start && lookahead <= range->end) {
-      return true;
-    } else if (lookahead > range->end) {
-      index = mid_index;
-    }
-    size -= half_size;
-  }
-  TSCharacterRange *range = &ranges[index];
-  return (lookahead >= range->start && lookahead <= range->end);
-}
-
 /*
  *  Lexer Macros
  */
@@ -175,17 +152,6 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {                          \
     state = state_value;     \
     goto next_state;         \
-  }
-
-#define ADVANCE_MAP(...)                                              \
-  {                                                                   \
-    static const uint16_t map[] = { __VA_ARGS__ };                    \
-    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
-      if (map[i] == lookahead) {                                      \
-        state = map[i + 1];                                           \
-        goto next_state;                                              \
-      }                                                               \
-    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -237,15 +203,14 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }                                 \
   }}
 
-#define REDUCE(symbol_name, children, precedence, prod_id) \
-  {{                                                       \
-    .reduce = {                                            \
-      .type = TSParseActionTypeReduce,                     \
-      .symbol = symbol_name,                               \
-      .child_count = children,                             \
-      .dynamic_precedence = precedence,                    \
-      .production_id = prod_id                             \
-    },                                                     \
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
   }}
 
 #define RECOVER()                    \

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -1,0 +1,99 @@
+================================================================================
+Block comment
+================================================================================
+
+/*
+ * Testing block comment
+*/
+fn void test(int foo)
+{
+  return foo - 1;
+}
+--------------------------------------------------------------------------------
+
+(source_file
+  (block_comment
+        (block_comment_text))
+      (func_definition
+        (func_header
+          (type
+            (base_type
+              (base_type_name)))
+          (ident))
+        (fn_parameter_list
+          (parameter
+            (type
+              (base_type
+                (base_type_name)))
+            (ident)))
+        (macro_func_body
+          (compound_stmt
+            (return_stmt
+              (binary_expr
+                (ident)
+                (integer_literal)))))))
+================================================================================
+Singleline Doc comment
+================================================================================
+<* @require foo > 0 *>
+fn int test(int foo)
+{
+  return foo - 1;
+}
+--------------------------------------------------------------------------------
+
+(source_file
+  (doc_comment
+        (doc_comment_text))
+      (func_definition
+        (func_header
+          (type
+            (base_type
+              (base_type_name)))
+          (ident))
+        (fn_parameter_list
+          (parameter
+            (type
+              (base_type
+                (base_type_name)))
+            (ident)))
+        (macro_func_body
+          (compound_stmt
+            (return_stmt
+              (binary_expr
+                (ident)
+                (integer_literal)))))))
+================================================================================
+Multiline Doc comment
+================================================================================
+<*
+@require foo > 0
+@ensure return < foo
+*>
+fn int test(int foo)
+{
+  return foo - 1;
+}
+--------------------------------------------------------------------------------
+
+(source_file
+  (doc_comment
+        (doc_comment_text))
+      (func_definition
+        (func_header
+          (type
+            (base_type
+              (base_type_name)))
+          (ident))
+        (fn_parameter_list
+          (parameter
+            (type
+              (base_type
+                (base_type_name)))
+            (ident)))
+        (macro_func_body
+          (compound_stmt
+            (return_stmt
+              (binary_expr
+                (ident)
+                (integer_literal)))))))


### PR DESCRIPTION
A very simple implementation of new doc comment syntaxt. This just "replaces" `/**` and `*/` with `<*` and `*>`, it does not provide any better highlighting for the content of the comment.

The important changes are in `grammar.js` & `src/scanner.c`, the rest is autogenerated.

Closes: #11 