### PR TITLE
Add highlight for open & close tags of doc comment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-c3",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-c3",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -320,6 +320,7 @@
   (block_comment)
 ] @comment @spell
 
+(doc_comment ["<*" "*>"] @comment.documentation @spell)
 (doc_comment_text) @comment.documentation @spell
 (doc_comment_contract_text) @comment.documentation @spell
 

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -13714,7 +13714,6 @@
   {
     "type": "source_file",
     "named": true,
-    "root": true,
     "fields": {},
     "children": {
       "multiple": true,

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -47,7 +47,6 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
-  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {
@@ -86,11 +85,6 @@ typedef union {
     bool reusable;
   } entry;
 } TSParseActionEntry;
-
-typedef struct {
-  int32_t start;
-  int32_t end;
-} TSCharacterRange;
 
 struct TSLanguage {
   uint32_t version;
@@ -131,24 +125,6 @@ struct TSLanguage {
   const TSStateId *primary_state_ids;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
-  uint32_t index = 0;
-  uint32_t size = len - index;
-  while (size > 1) {
-    uint32_t half_size = size / 2;
-    uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
-    if (lookahead >= range->start && lookahead <= range->end) {
-      return true;
-    } else if (lookahead > range->end) {
-      index = mid_index;
-    }
-    size -= half_size;
-  }
-  TSCharacterRange *range = &ranges[index];
-  return (lookahead >= range->start && lookahead <= range->end);
-}
-
 /*
  *  Lexer Macros
  */
@@ -176,17 +152,6 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
   {                          \
     state = state_value;     \
     goto next_state;         \
-  }
-
-#define ADVANCE_MAP(...)                                              \
-  {                                                                   \
-    static const uint16_t map[] = { __VA_ARGS__ };                    \
-    for (uint32_t i = 0; i < sizeof(map) / sizeof(map[0]); i += 2) {  \
-      if (map[i] == lookahead) {                                      \
-        state = map[i + 1];                                           \
-        goto next_state;                                              \
-      }                                                               \
-    }                                                                 \
   }
 
 #define SKIP(state_value) \
@@ -238,15 +203,14 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }                                 \
   }}
 
-#define REDUCE(symbol_name, children, precedence, prod_id) \
-  {{                                                       \
-    .reduce = {                                            \
-      .type = TSParseActionTypeReduce,                     \
-      .symbol = symbol_name,                               \
-      .child_count = children,                             \
-      .dynamic_precedence = precedence,                    \
-      .production_id = prod_id                             \
-    },                                                     \
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
   }}
 
 #define RECOVER()                    \

--- a/test/corpus/comments.txt
+++ b/test/corpus/comments.txt
@@ -167,3 +167,13 @@ Error doc
 *>
 
 --------------------------------------------------------------------------------
+
+(source_file
+  (doc_comment
+    (ERROR
+      (doc_comment_text)
+      (doc_comment_contract
+        (at_ident)
+        (doc_comment_contract_text))
+      (const_ident))
+    (doc_comment_text)))


### PR DESCRIPTION
I've extracted the open & close tags into their own symbol, so they can be highlighted selectively, this ensure that stuff like `@param` remains a regular text and not comment. It might also make it easier for external tools to extract the content of the doc string, but not sure about that.

![image](https://github.com/user-attachments/assets/0c48fcb5-045f-41b3-9746-f71c9f3e1475)