### PR TITLE
add parsing for doc comment contracts

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1188,7 +1188,7 @@ module.exports = grammar({
           '$defined',
           '$embed',
         ),
-        '(', commaSep($._expr), ')'
+        '(', commaSep($.call_arg), ')'
       ),
       seq('$feature', '(', $.const_ident, ')'),
       seq('$assignable', '(', $._expr, ',', $.type, ')'),

--- a/grammar.js
+++ b/grammar.js
@@ -88,9 +88,6 @@ module.exports = grammar({
   externals: $ => [
     $.block_comment_text,
     $.doc_comment_text,
-    $.doc_comment_contract_text,
-    // $.doc_comment_contract_code,
-    // $.doc_comment_contract_description,
     $.real_literal,
   ],
 
@@ -174,34 +171,33 @@ module.exports = grammar({
 
     // Doc comments and contracts
     // -------------------------
-    // NOTE parsed by scanner.c (scan_doc_comment_contract_text)
     doc_comment_contract_descriptor: _ => token(/\[&?(?:in|out|inout)\]/),
     doc_comment_contract: $ => seq(
-		choice(
-			seq(
-				field('name', alias('@param', $.at_ident)),
-				optional(field('mutability_contract', $.doc_comment_contract_descriptor)),
-				field('ident', choice($.ct_ident, $.hash_ident, $.ident, $.type)),
-				optional(':'),
-				optional($.string_expr)
-			),
-			field('name', alias('@pure', $.at_ident)),
-			seq(
-				field('name', alias(choice('@ensure', '@require'), $.at_ident)),
-				commaSep1($._expr),
-				optional(':'),
-				optional($.string_expr),
-			),
-			seq(
-				field('name', alias('@return', $.at_ident)),
-				choice(
-					seq('?', commaSep1(choice($.const_ident, $.module_ident_expr)), optional(':'), optional($.string_expr)),
-					$.string_expr,
-				)
-			),
-			seq(field('name', $.at_ident), optional($.string_expr)),
-		),
-		'\n'
+        choice(
+            seq(
+                field('name', alias('@param', $.at_ident)),
+                optional(field('mutability_contract', $.doc_comment_contract_descriptor)),
+                field('ident', choice($.ct_ident, $.hash_ident, $.ident, $.type)),
+                optional(':'),
+                optional($.string_expr)
+            ),
+            field('name', alias('@pure', $.at_ident)),
+            seq(
+                field('name', alias(choice('@ensure', '@require'), $.at_ident)),
+                commaSep1($._expr),
+                optional(':'),
+                optional($.string_expr),
+            ),
+            seq(
+                field('name', alias('@return', $.at_ident)),
+                choice(
+                    seq('?', commaSep1(choice($.const_ident, $.module_ident_expr)), optional(':'), optional($.string_expr)),
+                    $.string_expr,
+                )
+            ),
+            seq(field('name', $.at_ident), optional($.string_expr)),
+        ),
+        '\n'
     ),
     doc_comment: $ => seq(
       '<*',

--- a/grammar.js
+++ b/grammar.js
@@ -177,7 +177,7 @@ module.exports = grammar({
             seq(
                 field('name', alias('@param', $.at_ident)),
                 optional(field('mutability_contract', $.doc_comment_contract_descriptor)),
-                field('ident', choice($.ct_ident, $.hash_ident, $.ident, $.type)),
+                field('ident', choice($.ident, $.ct_ident, $.ct_type_ident, $.hash_ident)),
                 optional(':'),
                 optional($.string_expr)
             ),
@@ -191,7 +191,7 @@ module.exports = grammar({
             seq(
                 field('name', alias('@return', $.at_ident)),
                 choice(
-                    seq('?', commaSep1(choice($.const_ident, $.module_ident_expr)), optional(':'), optional($.string_expr)),
+                    seq('?', commaSep1($.path_const_ident), optional(':'), optional($.string_expr)),
                     $.string_expr,
                 )
             ),

--- a/grammar.js
+++ b/grammar.js
@@ -173,31 +173,31 @@ module.exports = grammar({
     // -------------------------
     doc_comment_contract_descriptor: _ => token(/\[&?(?:in|out|inout)\]/),
     doc_comment_contract: $ => seq(
-        choice(
-            seq(
-                field('name', alias('@param', $.at_ident)),
-                optional(field('mutability_contract', $.doc_comment_contract_descriptor)),
-                field('ident', choice($.ident, $.ct_ident, $.ct_type_ident, $.hash_ident)),
-                optional(':'),
-                optional($.string_expr)
-            ),
-            field('name', alias('@pure', $.at_ident)),
-            seq(
-                field('name', alias(choice('@ensure', '@require'), $.at_ident)),
-                commaSep1($._expr),
-                optional(':'),
-                optional($.string_expr),
-            ),
-            seq(
-                field('name', alias('@return', $.at_ident)),
-                choice(
-                    seq('?', commaSep1($.path_const_ident), optional(':'), optional($.string_expr)),
-                    $.string_expr,
-                )
-            ),
-            seq(field('name', $.at_ident), optional($.string_expr)),
+      choice(
+        seq(
+          field('name', alias('@param', $.at_ident)),
+          optional(field('mutability_contract', $.doc_comment_contract_descriptor)),
+          field('ident', choice($.ident, $.ct_ident, $.ct_type_ident, $.hash_ident)),
+          optional(':'),
+          optional($.string_expr)
         ),
-        '\n'
+        field('name', alias('@pure', $.at_ident)),
+        seq(
+          field('name', alias(choice('@ensure', '@require'), $.at_ident)),
+          commaSep1($._expr),
+          optional(':'),
+          optional($.string_expr),
+        ),
+        seq(
+          field('name', alias('@return', $.at_ident)),
+          choice(
+            seq('?', commaSep1($.path_const_ident), optional(':'), optional($.string_expr)),
+            $.string_expr,
+          )
+        ),
+        seq(field('name', $.at_ident), optional($.string_expr)),
+      ),
+      '\n'
     ),
     doc_comment: $ => seq(
       '<*',

--- a/grammar.js
+++ b/grammar.js
@@ -1184,7 +1184,7 @@ module.exports = grammar({
           '$defined',
           '$embed',
         ),
-        '(', commaSep($.call_arg), ')'
+        '(', commaSep(choice($._expr, $.type)), ')'
       ),
       seq('$feature', '(', $.const_ident, ')'),
       seq('$assignable', '(', $._expr, ',', $.type, ')'),

--- a/grammar.js
+++ b/grammar.js
@@ -89,6 +89,8 @@ module.exports = grammar({
     $.block_comment_text,
     $.doc_comment_text,
     $.doc_comment_contract_text,
+    // $.doc_comment_contract_code,
+    // $.doc_comment_contract_description,
     $.real_literal,
   ],
 
@@ -173,9 +175,33 @@ module.exports = grammar({
     // Doc comments and contracts
     // -------------------------
     // NOTE parsed by scanner.c (scan_doc_comment_contract_text)
+    doc_comment_contract_descriptor: _ => token(/\[&?(?:in|out|inout)\]/),
     doc_comment_contract: $ => seq(
-      field('name', $.at_ident),
-      optional($.doc_comment_contract_text)
+		choice(
+			seq(
+				field('name', alias('@param', $.at_ident)),
+				optional(field('mutability_contract', $.doc_comment_contract_descriptor)),
+				field('ident', choice($.ct_ident, $.hash_ident, $.ident, $.type)),
+				optional(':'),
+				optional($.string_expr)
+			),
+			field('name', alias('@pure', $.at_ident)),
+			seq(
+				field('name', alias(choice('@ensure', '@require'), $.at_ident)),
+				commaSep1($._expr),
+				optional(':'),
+				optional($.string_expr),
+			),
+			seq(
+				field('name', alias('@return', $.at_ident)),
+				choice(
+					seq('?', commaSep1(choice($.const_ident, $.module_ident_expr)), optional(':'), optional($.string_expr)),
+					$.string_expr,
+				)
+			),
+			seq(field('name', $.at_ident), optional($.string_expr)),
+		),
+		'\n'
     ),
     doc_comment: $ => seq(
       '<*',
@@ -1111,7 +1137,7 @@ module.exports = grammar({
       optional($.param_path),
     )),
 
-    string_expr: $ => repeat1(choice($.string_literal, $.raw_string_literal)),
+    string_expr: $ => prec.right(repeat1(choice($.string_literal, $.raw_string_literal))),
     bytes_expr: $ => repeat1($.bytes_literal),
     paren_expr: $ => seq('(', $._expr, ')'),
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -3,14 +3,8 @@
 enum TokenType {
   BLOCK_COMMENT_TEXT,
   DOC_COMMENT_TEXT,
-  DOC_COMMENT_CONTRACT_TEXT,
   REAL_LITERAL,
 };
-  // DOC_COMMENT_CONTRACT_CODE,
-  // DOC_COMMENT_CONTRACT_DESCRIPTION,
-
-  // DOC_COMMENT_CONTRACT_STRING,
-
 
 void *tree_sitter_c3_external_scanner_create() { return NULL; }
 void tree_sitter_c3_external_scanner_destroy(void *p) {}
@@ -85,61 +79,6 @@ static bool scan_doc_comment_text(TSLexer *lexer) {
   }
   return false;
 }
-
-static bool scan_doc_comment_contract_text(TSLexer *lexer) {
-  // We stop at EOF, newline or '*>'
-  bool has_text = false;
-  while (true) {
-    if (lexer->eof(lexer)) {
-      lexer->mark_end(lexer);
-      return false;
-    }
-
-    int32_t c = lexer->lookahead;
-    if (c == '\n') {
-      return has_text;
-    } else if (c == '*') {
-      lexer->advance(lexer, false);
-      if (lexer->lookahead == '>') {
-        return has_text;
-      }
-    }
-
-    bool whitespace = is_whitespace(c);
-    bool skip = !has_text && whitespace;
-    lexer->advance(lexer, skip);
-    if (!is_whitespace(c)) {
-      lexer->mark_end(lexer);
-      has_text = true;
-    }
-  }
-  return false;
-}
-
-/*static bool scan_doc_comment_contract_code(TSLexer *lexer) {
-	bool has_code = false;
-	while (true) {
-		if (lexer->eof(lexer)) {
-			lexer->mark_end(lexer);
-			return false;
-		}
-
-		int32_t c = lexer->lookahead;
-		if  (c == '\n') {
-			return has_code;
-		} else if (c == '*') {
-			lexer->advance(lexer, false);
-			if (lexer->lookahead == '>') {
-				return has_code;
-			}
-		}
-	}
-	return false;
-}*/
-
-/*static bool scan_doc_comment_contract_description(TSLexer *lexer) {
-
-}*/
 
 static bool is_digit(int32_t c) {
   return c >= '0' && c <= '9';
@@ -320,12 +259,6 @@ bool tree_sitter_c3_external_scanner_scan(void *payload, TSLexer *lexer,
                                           const bool *valid_symbols) {
   if (valid_symbols[BLOCK_COMMENT_TEXT] && scan_block_comment(lexer)) {
     lexer->result_symbol = BLOCK_COMMENT_TEXT;
-    return true;
-  }
-
-  // Before consuming whitespace because we need newlines
-  if (valid_symbols[DOC_COMMENT_CONTRACT_TEXT] && scan_doc_comment_contract_text(lexer)) {
-    lexer->result_symbol = DOC_COMMENT_CONTRACT_TEXT;
     return true;
   }
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -6,6 +6,11 @@ enum TokenType {
   DOC_COMMENT_CONTRACT_TEXT,
   REAL_LITERAL,
 };
+  // DOC_COMMENT_CONTRACT_CODE,
+  // DOC_COMMENT_CONTRACT_DESCRIPTION,
+
+  // DOC_COMMENT_CONTRACT_STRING,
+
 
 void *tree_sitter_c3_external_scanner_create() { return NULL; }
 void tree_sitter_c3_external_scanner_destroy(void *p) {}
@@ -110,6 +115,31 @@ static bool scan_doc_comment_contract_text(TSLexer *lexer) {
   }
   return false;
 }
+
+/*static bool scan_doc_comment_contract_code(TSLexer *lexer) {
+	bool has_code = false;
+	while (true) {
+		if (lexer->eof(lexer)) {
+			lexer->mark_end(lexer);
+			return false;
+		}
+
+		int32_t c = lexer->lookahead;
+		if  (c == '\n') {
+			return has_code;
+		} else if (c == '*') {
+			lexer->advance(lexer, false);
+			if (lexer->lookahead == '>') {
+				return has_code;
+			}
+		}
+	}
+	return false;
+}*/
+
+/*static bool scan_doc_comment_contract_description(TSLexer *lexer) {
+
+}*/
 
 static bool is_digit(int32_t c) {
   return c >= '0' && c <= '9';


### PR DESCRIPTION
I've never used tree-sitter before, so please tell me if there are any things I need to fix or change and I will fix them.

I've gone for correctness at the cost of a little verbosity & needing to be updated every time a new contract is added that takes more than a single string parameter.

this also fixes an issue where `@if($defined(TypeName))` would be an error, if you want me to move it to a separate PR/remove it I can do that.
this is the part that fixes it (if there is a better way, lmk):
```diff
-        '(', commaSep($._expr), ')'
+        '(', commaSep($.call_arg), ')'
```