### PR TITLE
Python bindings were missing the src/scanner.c source file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
             sources=[
                 "bindings/python/tree_sitter_c3/binding.c",
                 "src/parser.c",
-                # NOTE: if your language uses an external scanner, add it here.
+                "src/scanner.c"
             ],
             extra_compile_args=[
                 "-std=c11",


### PR DESCRIPTION
I tried working with the python binding : 
```py
from tree_sitter import Language, Parser 
import tree_sitter_c3

parser = Parser(Language(tree_sitter_c3.language()))
```

but stumbled accros this error : 
```
Traceback (most recent call last):
  File "/home/lucas/devel/c3-format/main.py", line 2, in <module>
    import tree_sitter_c3
  File "/usr/lib/python3.13/site-packages/tree_sitter_c3/__init__.py", line 3, in <module>
    from ._binding import language
```

`setup.py`actually had the solution in a comment.

I'm still getting a warning that might be looked at : 
```
DeprecationWarning: int argument support is deprecated
  parser = Parser(Language(tree_sitter_c3.language()))
```
