### PR TITLE
feat: Update generics syntax and add support for contracts

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -98,7 +98,6 @@ export default grammar({
     /\s|\r?\n/, // White space and line endings
     $.line_comment,
     $.block_comment,
-    $.doc_comment,
   ],
 
   // WARNING: must be in the same order as scanner.c TokenType enum
@@ -228,7 +227,6 @@ export default grammar({
       repeat($.doc_comment_contract),
       '*>',
     ),
-
     block_comment: $ => seq(
       '/*',
       // NOTE parsed by scanner.c (scan_block_comment_scanner)
@@ -415,8 +413,9 @@ export default grammar({
     // Module
     // -------------------------
     _module_param: $ => choice($.const_ident, $.type_ident),
-    generic_param_list: $ => seq('{', commaSep1($._module_param), '}'),
+    generic_param_list: $ => seq('<', commaSep1($._module_param), '>'),
     module_declaration: $ => seq(
+      optional($.doc_comment),
       'module',
       field('path', $.path_ident),
       optional($.generic_param_list),
@@ -427,6 +426,7 @@ export default grammar({
     // Import
     // -------------------------
     import_declaration: $ => seq(
+      optional($.doc_comment),
       'import',
       field('path', commaSep1($.path_ident)),
       optional($.attributes),
@@ -443,6 +443,7 @@ export default grammar({
     ),
 
     alias_declaration: $ => seq(
+      optional($.doc_comment),
       'alias',
       choice(
         // Variable/function/macro/method/module
@@ -463,6 +464,7 @@ export default grammar({
         // Type/function
         seq(
           field('name', $.type_ident),
+          optional($.generic_param_list),
           optional($.attributes),
           '=',
           choice($._type_expr, $.func_signature)
@@ -474,6 +476,7 @@ export default grammar({
     // Faultdef
     // -------------------------
     faultdef_declaration: $ => seq(
+      optional($.doc_comment),
       'faultdef',
       commaSep1($.const_ident),
       optional($.attributes),
@@ -483,6 +486,7 @@ export default grammar({
     // Typedef
     // -------------------------
     typedef_declaration: $ => seq(
+      optional($.doc_comment),
       'typedef',
       field('name', $.type_ident),
       optional($.interface_impl_list),
@@ -499,6 +503,7 @@ export default grammar({
     attribute_list: $ => commaSep1($.attribute),
     attribute_param_list: $ => seq('(', $._parameters, ')'),
     attrdef_declaration: $ => seq(
+      optional($.doc_comment),
       'attrdef',
       field('name', $.at_type_ident),
       optional($.attribute_param_list),
@@ -523,9 +528,10 @@ export default grammar({
     identifier_list: $ => commaSep1($._decl_ident),
 
     struct_member_declaration: $ => choice(
-      seq(field('type', $.type), $.identifier_list, optional($.attributes), ';'),
-      seq($._struct_or_union, optional($.ident), optional($.attributes), field('body', $.struct_body)),
+      seq(optional($.doc_comment), field('type', $.type), $.identifier_list, optional($.attributes), ';'),
+      seq(optional($.doc_comment), $._struct_or_union, optional($.ident), optional($.attributes), field('body', $.struct_body)),
       seq(
+        optional($.doc_comment),
         'bitstruct',
         optional($.ident),
         ':',
@@ -533,7 +539,7 @@ export default grammar({
         optional($.attributes),
         field('body', $.bitstruct_body)
       ),
-      seq('inline', field('type', $.type), optional($.ident), optional($.attributes), ';'),
+      seq(optional($.doc_comment), 'inline', field('type', $.type), optional($.ident), optional($.attributes), ';'),
     ),
     struct_body: $ => seq(
       '{',
@@ -542,8 +548,10 @@ export default grammar({
       '}',
     ),
     struct_declaration: $ => seq(
+      optional($.doc_comment),
       $._struct_or_union,
       field('name', $.type_ident),
+      optional($.generic_param_list),
       optional($.interface_impl_list),
       optional($.attributes),
       field('body', $.struct_body),
@@ -552,6 +560,7 @@ export default grammar({
     // Bitstruct
     // -------------------------
     bitstruct_member_declaration: $ => seq(
+      optional($.doc_comment),
       field('type', $._base_type),
       $.ident,
       optional(seq(
@@ -571,8 +580,10 @@ export default grammar({
       '}',
     ),
     bitstruct_declaration: $ => seq(
+      optional($.doc_comment),
       'bitstruct',
       field('name', $.type_ident),
+      optional($.generic_param_list),
       optional($.interface_impl_list),
       ':',
       alias($._type_no_generics, $.type),
@@ -584,6 +595,7 @@ export default grammar({
     // -------------------------
     enum_arg: $ => seq('=', $._expr),
     enum_constant: $ => seq(
+      optional($.doc_comment),
       field('name', $.const_ident),
       optional($.attributes),
       field('args', optional($.enum_arg)),
@@ -612,8 +624,10 @@ export default grammar({
       '}'
     ),
     enum_declaration: $ => seq(
+      optional($.doc_comment),
       'enum',
       field('name', $.type_ident),
+      optional($.generic_param_list),
       optional($.interface_impl_list),
       optional($.enum_spec),
       optional($.attributes),
@@ -624,8 +638,10 @@ export default grammar({
     // -------------------------
     interface_body: $ => seq('{', repeat($.func_declaration), '}'),
     interface_declaration: $ => seq(
+      optional($.doc_comment),
       'interface',
       field('name', $.type_ident),
+      optional($.generic_param_list),
       optional(seq(
         ':',
         commaSep1($.type_ident),
@@ -650,17 +666,21 @@ export default grammar({
     func_param_list: $ => seq('(', optional($._parameters), ')'),
 
     func_declaration: $ => seq(
+      optional($.doc_comment),
       'fn',
       $.func_header,
       $.func_param_list,
+      optional($.generic_param_list),
       optional($.attributes),
       ';',
     ),
 
     func_definition: $ => prec.right(seq(
+      optional($.doc_comment),
       'fn',
       $.func_header,
       $.func_param_list,
+      optional($.generic_param_list),
       optional($.attributes),
       // The body is made optional to improve error recovery for syntax highlighting (PR #41)
       field('body', optional($.macro_func_body)),
@@ -695,9 +715,11 @@ export default grammar({
     ),
 
     macro_declaration: $ => seq(
+      optional($.doc_comment),
       'macro',
       $.macro_header,
       $.macro_param_list,
+      optional($.generic_param_list),
       optional($.attributes),
       field('body', $.macro_func_body),
     ),
@@ -763,9 +785,9 @@ export default grammar({
     // Var Statement
     // -------------------------
     var_declaration: $ => choice(
-      seq('var', field('name', $.ident), optional($.attributes), $._assign_right_expr),
-      seq('var', field('name', $.ct_ident), optional($.attributes), optional($._assign_right_expr)),
-      seq('var', field('name', $.ct_type_ident), optional($.attributes), optional($._assign_right_expr)),
+      seq(optional($.doc_comment), 'var', field('name', $.ident), optional($.attributes), $._assign_right_expr),
+      seq(optional($.doc_comment), 'var', field('name', $.ct_ident), optional($.attributes), optional($._assign_right_expr)),
+      seq(optional($.doc_comment), 'var', field('name', $.ct_type_ident), optional($.attributes), optional($._assign_right_expr)),
     ),
     var_stmt: $ => seq($.var_declaration, ';'),
 
@@ -819,6 +841,7 @@ export default grammar({
     ),
 
     const_declaration: $ => seq(
+      optional($.doc_comment),
       'const',
       field('type', optional($.type)),
       field('name', $.const_ident),
@@ -831,12 +854,10 @@ export default grammar({
       $.const_declaration,
     ),
 
-    global_declaration: $ => seq(
-      optional('extern'),
-      choice(
-        seq($._declaration, ';'),
-        $.func_declaration,
-      ),
+    global_declaration: $ => choice(
+      seq(optional($.doc_comment), 'extern', choice(seq($._declaration, ';'), $.func_declaration)),
+      seq($._declaration, ';'),
+      $.func_declaration,
     ),
 
     // Case Statement
@@ -942,6 +963,7 @@ export default grammar({
     ),
 
     single_declaration: $ => seq(
+      optional($.doc_comment),
       field('type', $.type),
       $._single_decl_after_type
     ),
@@ -1240,7 +1262,7 @@ export default grammar({
         ),
         $.paren_expr,
       ),
-      seq('$embed','(', commaSep($._expr), ')'),
+      seq('$embed', '(', commaSep($._expr), ')'),
       seq('$defined', '(', commaSep($._decl_or_expr), ')'),
       seq('$feature', '(', $.const_ident, ')'),
       seq('$assignable', '(', $._expr, ',', $._expr, ')'), // Deprecated >= 0.7.4
@@ -1325,6 +1347,8 @@ export default grammar({
     optional_expr: $ => prec.right(PREC.TERNARY, seq(
       field('argument', $._expr),
       field('operator', choice(
+        '~',
+        seq('~', '!'),
         '?',
         seq('?', '!'),
       )),
@@ -1575,12 +1599,12 @@ export default grammar({
         $.generic_type_ident
       ),
       repeat($.type_suffix),
-      optional('?'),
+      optional(choice('~', '?')),
     )),
     _type_no_generics: $ => prec.right(seq(
       $._base_type,
       repeat($.type_suffix),
-      optional('?'),
+      optional(choice('~', '?')),
     )),
   }
 });


### PR DESCRIPTION
- Changed generic parameter definitions to use angle brackets `<...>` instead of braces.
- Added support for the optional type suffix `~`.
- Implemented C3 contracts (doc comments `<* ... *>`) as children nodes for functions, structs, types, and variables.
- Resolved grammar ambiguities in global declarations caused by the new contract syntax.

---
edit: @cbuttner 

- revert comment unification and restrict doc comment repetition
- split comment node back into line_comment and block_comment in grammar.js
- revert highlights.scm
- Replace `repeat($.doc_comment)` with `optional($.doc_comment)`