### PR TITLE
Fixed "\c" escape sequence breaking the LSP

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -140,7 +140,7 @@ export default grammar({
     escape_sequence: _ => token(prec(1, seq(
       '\\',
       choice(
-        /[0abefnrtv'"\\]/,
+        /[0abcefnrtv'"\\]/,
         /x[0-9a-fA-F]{2}/,
         /u[0-9a-fA-F]{4}/,
         /U[0-9a-fA-F]{8}/,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -117,7 +117,7 @@
               "members": [
                 {
                   "type": "PATTERN",
-                  "value": "[0abefnrtv'\"\\\\]"
+                  "value": "[0abcefnrtv'\"\\\\]"
                 },
                 {
                   "type": "PATTERN",


### PR DESCRIPTION
In this commit, I added the \c escape sequence to the regex defined in grammar.js. before, having a \c escape sequence in your code would break the LSP output (everything after would be grey).
